### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,11 @@ pip install -e git+git://github.com/pduchesne/ckanext-geoview.git#egg=ckanext-ge
 Then add the ```geoview``` (for CKAN 2.3+) or the ```geopreview``` plugin (for older versions)
 into the ```ckan.plugins``` section of your .ini file.
 
+For CKAN versions 2.2 and older, ensure you have the Resource Proxy enabled. This is done by adding ``resource_proxy`` to the ``ckan.plugins`` section of your .ini file and adding this config option:
+```
+ckan.resource_proxy_enabled = True
+```
+ 
 To be able to view Google Fusion Tables resources, a Google API Key must be configured in the .ini file :
 
 ```


### PR DESCRIPTION
Mention the Resource Proxy (I realize it's pretty obvious, but why not...)

BTW have I got it right that it only needs doing for CKAN 2.2 and earlier? I get the impression CKAN 2.3 has it enabled by default or something?
