### PR TITLE
Cope with another version of bounds in ESRI API

### DIFF
--- a/ckanext/geoview/public/js/vendor/ol-helpers/ol-helpers.js
+++ b/ckanext/geoview/public/js/vendor/ol-helpers/ol-helpers.js
@@ -207,6 +207,12 @@ ol.proj.addProjection(createEPSG4326Proj('EPSG:4326:LONLAT', 'enu'));
 
     var getArcGISVectorExtent = function() {
         var bbox = this.get('arcgisDescr') && this.get('arcgisDescr').bounds;
+        if (!bbox) {
+            bbox_obj = this.get('arcgisDescr').extent;
+            if (bbox_obj) {
+                bbox = [bbox_obj['xmin'], bbox_obj['ymin'], bbox_obj['xmax'], bbox_obj['ymax']];            
+            }
+        }
         return bbox;
     }
 


### PR DESCRIPTION
I am not familiar with ESRI's API, but this did the trick in dealing with the dataset we are looking at, and shouldn't break anything else